### PR TITLE
Ignore empty entry in breadcrumb on start page

### DIFF
--- a/themes/classic/templates/_partials/breadcrumb.tpl
+++ b/themes/classic/templates/_partials/breadcrumb.tpl
@@ -32,7 +32,7 @@
               <a itemprop="item" href="{$path.url}"><span itemprop="name">{$path.title}</span></a>
               <meta itemprop="position" content="{$smarty.foreach.breadcrumb.iteration}">
             </li>
-          {else}
+          {elseif isset($path.title)}
             <li>
               <span>{$path.title}</span>
             </li>


### PR DESCRIPTION
Fix issue #15302
https://github.com/PrestaShop/PrestaShop/issues/15302

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | see issue
| Type?         | bug fix 
| Category?     | FO
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? |  Fixes #15302
| How to test?  | Open home category

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
